### PR TITLE
Fix mobile menu overflow on small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,10 +84,10 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border outline-ring/50 box-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'framer-motion'; // eslint-disable-line no-unused-vars
 import { 
   Leaf, 
   TrendingUp, 
@@ -27,8 +27,6 @@ import './App.css';
 import pecuariaLogo from './assets/pecuaria_logo.svg';
 import heroImage from './assets/banner_pecumais4.webp';
 import sustainableImage from './assets/xcXwS7plUGet.jpg';
-import regenerativeImage from './assets/3fiwOK2RcRpo.jpg';
-import familyFarmImage from './assets/bFuKBr7V6bFG.jpg';
 
 function App() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+// Resolve __dirname in ES module context
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- prevent horizontal overflow by enforcing border-box sizing and hiding body overflow
- resolve __dirname in Vite config for lint compatibility
- clean up unused imports

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b74ad689d88331830f4f05804c8c50