### PR TITLE
Enhance navbar link readability

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -295,6 +295,10 @@ html {
   overflow-x: hidden;
 }
 
+.nav-link {
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}
+
 @media (max-width: 600px) {
   html, body {
     overflow-x: hidden;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -475,7 +475,7 @@ function App() {
   };
 
   const navLinkClasses =
-    'font-semibold tracking-tight text-white hover:text-[#ffd301] transition-colors';
+    'nav-link font-semibold tracking-tight text-white hover:text-[#ffd301] transition-colors';
 
   const cardHover = {
     whileHover: { y: -10, scale: 1.01 },


### PR DESCRIPTION
## Summary
- add a reusable nav-link class to give navbar items a dark outline
- apply the new class to desktop navigation buttons so their text remains readable on light backgrounds

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b2472bfc83319c58084408ae20db