### PR TITLE
Fix mobile layout overflow and spacing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -320,9 +320,9 @@ html {
   }
 
   section {
-    overflow-x: hidden;
-    overflow-y: visible;
+    width: 100%;
     max-width: 100vw;
+    overflow: visible;
   }
 
   .btn-primary,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -697,7 +697,7 @@ function App() {
       />
 
       {/* Por que Pecuária Sustentável */}
-      <section id="why" className="section-padding relative overflow-visible md:overflow-hidden">
+      <section id="why" className="section-padding relative overflow-hidden">
         <div className="absolute inset-0">
           <img
             src={porqueImage}
@@ -851,7 +851,7 @@ function App() {
       />
 
       {/* Vídeos */}
-      <section id="videos" className="section-padding">
+      <section id="videos" className="section-padding pt-12 pb-16 sm:pt-16 sm:pb-20">
         <div className="container mx-auto px-4">
           <motion.div
             initial={{ opacity: 0, y: 30 }}
@@ -866,9 +866,9 @@ function App() {
             />
           </motion.div>
 
-          <div className="rounded-2xl bg-gray-light p-10 text-center text-green-secondary md:p-16">
-            <Play size={48} className="mx-auto mb-6 text-green-secondary md:size-16" />
-            <p className="text-xl font-semibold text-[#074536] md:text-2xl">
+          <div className="rounded-2xl bg-gray-light px-6 py-10 text-center text-green-secondary sm:px-8 sm:py-12 md:px-12 md:py-16">
+            <Play size={48} className="mx-auto mb-6 text-green-secondary md:mb-8 md:size-16" />
+            <p className="text-lg font-semibold text-[#074536] sm:text-xl md:text-2xl">
               {currentContent.videos.placeholder}
             </p>
           </div>
@@ -876,7 +876,7 @@ function App() {
       </section>
 
       {/* Publicações */}
-      <section id="publications" className="section-padding relative overflow-visible md:overflow-hidden">
+      <section id="publications" className="section-padding relative overflow-hidden">
         <div className="absolute inset-0">
           <img
             src={publiImage}
@@ -943,7 +943,7 @@ function App() {
       </section>
 
       {/* Chatbot */}
-   <section id="chatbot" className="section-padding relative overflow-visible md:overflow-hidden">
+      <section id="chatbot" className="section-padding relative overflow-hidden">
         {/* Mascote como background da seção */}
         <div className="pointer-events-none absolute right-0 top-1/2 -translate-y-1/2 transform">
           <img

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -89,7 +89,7 @@ const Contact = ({ content }) => {
       id="contact"
       className="section-padding bg-gradient-to-r from-[#f0f9ff] via-[#e8fff4] to-[#fff5e6]"
     >
-      <div className="container mx-auto px-4">
+      <div className="container mx-auto max-w-6xl px-4">
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
@@ -105,7 +105,7 @@ const Contact = ({ content }) => {
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
           >
-            <Card className="bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
+            <Card className="w-full bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
               <h3 className="text-xl font-bold text-[#0f5132] mb-6 md:text-2xl">Envie uma mensagem</h3>
               <form className="space-y-6" onSubmit={handleSubmit} noValidate>
                 <div>
@@ -182,7 +182,7 @@ const Contact = ({ content }) => {
             transition={{ duration: 0.6 }}
             className="space-y-8"
           >
-            <Card className="bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
+            <Card className="w-full bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
               <h3 className="text-xl font-bold text-[#0f5132] mb-6 md:text-2xl">Informações de Contato</h3>
               <div className="space-y-6">
                 <div className="flex items-start space-x-4">

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -144,7 +144,7 @@ const Hero = ({ content, backgroundImage, onPrimaryClick, onSecondaryClick }) =>
   return (
     <section
       id="home"
-      className="relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-[#074536]"
+      className="relative flex min-h-[100svh] w-full items-center justify-center overflow-hidden bg-[#074536] lg:min-h-screen"
       style={{ fontFamily: '"Manrope", "Inter", sans-serif' }}
     >
       <div className="absolute inset-0">

--- a/src/components/Practices.jsx
+++ b/src/components/Practices.jsx
@@ -16,7 +16,7 @@ const Practices = ({ title, subtitle, items }) => {
   };
 
   return (
-    <section id="practices" className="section-padding relative overflow-visible md:overflow-hidden">
+    <section id="practices" className="section-padding relative overflow-hidden">
       <div className="absolute inset-0">
         <img
           src={pecuariaBanner}


### PR DESCRIPTION
## Summary
- prevent mobile sections from creating nested scroll areas by updating overflow rules and section wrappers
- refine the videos placeholder padding and hero/contact layouts for better mobile spacing and width
- ensure decorative backgrounds stay clipped on small screens by tightening overflow handling on key sections

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dacda2e2288331b27d0bb5cad5e0d5