### PR TITLE
Fix mobile overflow issues on sustainable livestock page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -697,7 +697,7 @@ function App() {
       />
 
       {/* Por que Pecuária Sustentável */}
-      <section id="why" className="section-padding relative overflow-hidden">
+      <section id="why" className="section-padding relative overflow-visible lg:overflow-hidden">
         <div className="absolute inset-0">
           <img
             src={porqueImage}
@@ -876,7 +876,7 @@ function App() {
       </section>
 
       {/* Publicações */}
-      <section id="publications" className="section-padding relative overflow-hidden">
+      <section id="publications" className="section-padding relative overflow-visible lg:overflow-hidden">
         <div className="absolute inset-0">
           <img
             src={publiImage}

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -105,7 +105,7 @@ const Contact = ({ content }) => {
             whileInView={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.6 }}
           >
-            <Card className="w-full bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
+            <Card className="w-full max-w-full bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
               <h3 className="text-xl font-bold text-[#0f5132] mb-6 md:text-2xl">Envie uma mensagem</h3>
               <form className="space-y-6" onSubmit={handleSubmit} noValidate>
                 <div>
@@ -182,7 +182,7 @@ const Contact = ({ content }) => {
             transition={{ duration: 0.6 }}
             className="space-y-8"
           >
-            <Card className="w-full bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
+            <Card className="w-full max-w-full bg-white/90 p-6 shadow-xl border border-[#74c69d]/25 backdrop-blur md:p-8">
               <h3 className="text-xl font-bold text-[#0f5132] mb-6 md:text-2xl">Informações de Contato</h3>
               <div className="space-y-6">
                 <div className="flex items-start space-x-4">

--- a/src/components/Practices.jsx
+++ b/src/components/Practices.jsx
@@ -16,7 +16,7 @@ const Practices = ({ title, subtitle, items }) => {
   };
 
   return (
-    <section id="practices" className="section-padding relative overflow-hidden">
+    <section id="practices" className="section-padding relative overflow-visible lg:overflow-hidden">
       <div className="absolute inset-0">
         <img
           src={pecuariaBanner}


### PR DESCRIPTION
## Summary
- allow the "Por que", "Práticas" and "Publicações" sections to expand naturally on small screens to avoid nested scrolling
- ensure both contact cards respect the mobile viewport width by capping their max width

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68dada90b47c83318f91a85f6197e3c8