### PR TITLE
Fix viewport min height on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -485,7 +485,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-white overflow-x-hidden max-w-[100vw]">
+    <div className="min-h-screen min-h-[100svh] bg-white overflow-x-hidden max-w-[100vw]">
       {/* Navegação */}
       <nav className={`navbar-fixed ${isScrolled ? 'shadow-lg' : ''}`}>
         <div className="container mx-auto px-4 py-4">

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -144,7 +144,7 @@ const Hero = ({ content, backgroundImage, onPrimaryClick, onSecondaryClick }) =>
   return (
     <section
       id="home"
-      className="relative flex min-h-[100svh] w-full items-center justify-center overflow-hidden bg-[#074536] lg:min-h-screen"
+      className="relative flex min-h-screen min-h-[100svh] w-full items-center justify-center overflow-hidden bg-[#074536] lg:min-h-screen"
       style={{ fontFamily: '"Manrope", "Inter", sans-serif' }}
     >
       <div className="absolute inset-0">


### PR DESCRIPTION
## Summary
- add small viewport height fallback to the main app container to prevent unwanted mobile scrolling
- ensure the hero section also uses the 100svh override while keeping 100vh as a fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daea14c6b88331b008ca782e6481fb