### PR TITLE
Add subtle outline to navigation links

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -319,7 +319,8 @@ html {
 }
 
 .nav-link {
-  color:#ffffff
+  color:#ffffff;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.35);
 }
 
 .nav-link:hover {


### PR DESCRIPTION
## Summary
- add a subtle black outline to navigation links via a text shadow for better legibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deb0510568833199e457c7398ada1d