### PR TITLE
Centralize mobile navigation links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -603,12 +603,12 @@ function App() {
               animate={{ opacity: 1, y: 0 }}
               className="lg:hidden mt-4 pb-4 border-t border-white/10 bg-green-dark backdrop-blur-xl max-w-full overflow-x-hidden rounded-3xl px-4"
             >
-              <div className="flex flex-col space-y-4 pt-4 w-full">
+              <div className="flex flex-col items-center space-y-4 pt-4 w-full">
                 <motion.button
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('home')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.home}
                 </motion.button>
@@ -616,7 +616,7 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('why')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.why}
                 </motion.button>
@@ -624,7 +624,7 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('about')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.about}
                 </motion.button>
@@ -632,7 +632,7 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('practices')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.practices}
                 </motion.button>
@@ -640,7 +640,7 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('videos')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.videos}
                 </motion.button>
@@ -648,7 +648,7 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('publications')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.publications}
                 </motion.button>
@@ -656,7 +656,7 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('chatbot')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.chatbot}
                 </motion.button>
@@ -664,11 +664,11 @@ function App() {
                   {...navMotion}
                   type="button"
                   onClick={() => scrollToSection('contact')}
-                  className={`text-left ${navLinkClasses}`}
+                  className={`w-full text-center ${navLinkClasses}`}
                 >
                   {currentContent.nav.contact}
                 </motion.button>
-                <div className="flex space-x-2 pt-2">
+                <div className="flex justify-center space-x-2 pt-2">
                   <motion.button
                     {...navMotion}
                     type="button"


### PR DESCRIPTION
## Summary
- center the mobile navigation buttons within the expanded menu
- ensure language selector buttons are centered to match the links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deb20b22b48331bc43b940625ea2a7