### PR TITLE
Center chatbot CTA button on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1135,7 +1135,7 @@ function App() {
                 initial={{ opacity: 0, y: 30 }}
                 whileInView={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6, delay: 0.9 }}
-                className="pt-4"
+                className="pt-4 flex justify-center lg:justify-start"
               >
                 <motion.button
                   type="button"


### PR DESCRIPTION
## Summary
- center the chatbot call-to-action button on smaller viewports while keeping desktop alignment

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68deb49e4dcc8331b28c7aec042c8321